### PR TITLE
[AC-7351] handle related fields in tablib

### DIFF
--- a/django_tablib/admin/__init__.py
+++ b/django_tablib/admin/__init__.py
@@ -110,6 +110,7 @@ class TablibAdmin(admin.ModelAdmin):
             self.list_max_show_all,
             self.list_editable,
             self,
+            self.sortable_by
         )
         return cl.get_queryset(request)
 

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -91,5 +91,7 @@ def resolve_related_value(obj, attr):
     related_field = obj
     for field in fields:
         related_field = getattr(related_field, field)
+        if related_field is None:
+            break
 
     return related_field

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -54,7 +54,10 @@ class BaseDataset(tablib.Dataset):
                 if hasattr(obj, 'get_{0}_display'.format(attr)):
                     value = getattr(obj, 'get_{0}_display'.format(attr))()
                 else:
-                    value = getattr(obj, attr)
+                    if '.' in attr:
+                        value = resolve_related_value(obj, attr)
+                    else:
+                        value = getattr(obj, attr)
                 attr = self._cleanval(value, attr)
             attrs.append(attr)
         return attrs
@@ -81,3 +84,13 @@ class BaseDataset(tablib.Dataset):
             row = django_object
 
         super(BaseDataset, self).append(row=row, col=col)
+
+
+def resolve_related_value(obj, attr):
+    fields = attr.split('.')
+    related_field = obj
+    for field in fields:
+        related_field = getattr(related_field, field)
+
+    return related_field
+

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -54,10 +54,7 @@ class BaseDataset(tablib.Dataset):
                 if hasattr(obj, 'get_{0}_display'.format(attr)):
                     value = getattr(obj, 'get_{0}_display'.format(attr))()
                 else:
-                    if '.' in attr:
-                        value = resolve_related_value(obj, attr)
-                    else:
-                        value = getattr(obj, attr)
+                    value = get_attribute_value(obj, attr)
                 attr = self._cleanval(value, attr)
             attrs.append(attr)
         return attrs
@@ -86,7 +83,7 @@ class BaseDataset(tablib.Dataset):
         super(BaseDataset, self).append(row=row, col=col)
 
 
-def resolve_related_value(obj, attr):
+def get_attribute_value(obj, attr):
     fields = attr.split('.')
     related_field = obj
     for field in fields:

--- a/django_tablib/base.py
+++ b/django_tablib/base.py
@@ -93,4 +93,3 @@ def resolve_related_value(obj, attr):
         related_field = getattr(related_field, field)
 
     return related_field
-

--- a/testproject/tablib_test/tests.py
+++ b/testproject/tablib_test/tests.py
@@ -25,7 +25,7 @@ class DjangoTablibTestCase(TestCase):
         self.assertTrue('field2' in data.headers)
         self.assertTrue('Field 1' in data.headers)
 
-        self.assertEqual(data[0][0], data[0][1])
+        self.assertEqual(data[0][1], data[0][2]])
 
     def test_meta_fields(self):
         class TestModelDataset(ModelDataset):

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -40,7 +40,7 @@ INSTALLED_APPS = (
     'tablib_test',
 )
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
@@ -82,3 +82,19 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/1.6/howto/static-files/
 
 STATIC_URL = '/static/'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            'context_processors': [
+                'django.template.context_processors.debug',
+                'django.template.context_processors.request',
+                'django.contrib.auth.context_processors.auth',
+                'django.contrib.messages.context_processors.messages',
+            ],
+        },
+    },
+]

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -3,10 +3,10 @@ from django.conf.urls import include, url
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = ('',
+urlpatterns = (
     # Examples:
     # url(r'^$', 'testproject.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),
 
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
 )

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import patterns, include, url
+from django.conf.urls import include, url
 
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
+urlpatterns = ('',
     # Examples:
     # url(r'^$', 'testproject.views.home', name='home'),
     # url(r'^blog/', include('blog.urls')),


### PR DESCRIPTION
[JIRA](https://masschallenge.atlassian.net/browse/AC-7351)
We are unable to export Panel reports because django-tablib does not support using related fields in the headers. this pr fixes that

To test - 
 - unknown